### PR TITLE
Move email notification record keeping to its own model

### DIFF
--- a/api/src/main/kotlin/com/joe/quizzy/api/models/EmailNotification.kt
+++ b/api/src/main/kotlin/com/joe/quizzy/api/models/EmailNotification.kt
@@ -1,0 +1,14 @@
+package com.joe.quizzy.api.models
+
+import java.util.UUID
+
+enum class NotificationType {
+    REMINDER,
+    ANSWER
+}
+
+data class EmailNotification(
+    val id: UUID?,
+    val notificationType: NotificationType,
+    val questionId: UUID
+)

--- a/api/src/main/kotlin/com/joe/quizzy/api/models/Question.kt
+++ b/api/src/main/kotlin/com/joe/quizzy/api/models/Question.kt
@@ -10,7 +10,5 @@ data class Question(
     val answer: String,
     val ruleReferences: String,
     val activeAt: OffsetDateTime,
-    val closedAt: OffsetDateTime,
-    val sentReminder: Boolean = false,
-    val sentAnswer: Boolean = false
+    val closedAt: OffsetDateTime
 )

--- a/persistence/src/main/kotlin/com/joe/quizzy/persistence/api/EmailNotificationDAO.kt
+++ b/persistence/src/main/kotlin/com/joe/quizzy/persistence/api/EmailNotificationDAO.kt
@@ -1,0 +1,10 @@
+package com.joe.quizzy.persistence.api
+
+import com.joe.quizzy.api.models.EmailNotification
+import com.joe.quizzy.api.models.NotificationType
+import java.util.UUID
+
+interface EmailNotificationDAO {
+    fun markNotified(notificationType: NotificationType, questionUUIDs: List<UUID>)
+    fun all(): List<EmailNotification>
+}

--- a/persistence/src/main/kotlin/com/joe/quizzy/persistence/api/QuestionDAO.kt
+++ b/persistence/src/main/kotlin/com/joe/quizzy/persistence/api/QuestionDAO.kt
@@ -1,12 +1,13 @@
 package com.joe.quizzy.persistence.api
 
+import com.joe.quizzy.api.models.NotificationType
 import com.joe.quizzy.api.models.Question
 import com.joe.quizzy.api.models.User
 import java.util.UUID
 import java.util.stream.Stream
 
 /**
- * DAO for managing Things
+ * DAO for managing Questions
  */
 interface QuestionDAO {
     fun all(): List<Question>
@@ -16,7 +17,9 @@ interface QuestionDAO {
     fun save(thing: Question): Question
     fun active(): List<Question>
     fun active(user: User): List<Question>
+    fun active(notificationType: NotificationType): List<Question>
     fun closed(): List<Question>
     fun closed(user: User): List<Question>
+    fun closed(notificationType: NotificationType): List<Question>
     fun future(user: User): List<Question>
 }

--- a/persistence/src/main/kotlin/com/joe/quizzy/persistence/impl/EmailNotificationDAOJooq.kt
+++ b/persistence/src/main/kotlin/com/joe/quizzy/persistence/impl/EmailNotificationDAOJooq.kt
@@ -1,0 +1,34 @@
+package com.joe.quizzy.persistence.impl
+
+import com.joe.quizzy.api.models.EmailNotification
+import com.joe.quizzy.api.models.NotificationType
+import com.joe.quizzy.persistence.api.EmailNotificationDAO
+import com.joe.quizzy.persistence.impl.jooq.Tables
+import org.jooq.DSLContext
+import java.util.UUID
+import javax.inject.Inject
+
+class EmailNotificationDAOJooq @Inject constructor(
+    private val ctx: DSLContext
+) : EmailNotificationDAO {
+    override fun markNotified(notificationType: NotificationType, questionUUIDs: List<UUID>) {
+        if (questionUUIDs.isNotEmpty()) {
+            ctx.transaction { config ->
+                val firstRecord = config.dsl().insertInto(Tables.EMAIL_NOTIFICATIONS)
+                    .set(Tables.EMAIL_NOTIFICATIONS.NOTIFICATION_TYPE, notificationType.name)
+                    .set(Tables.EMAIL_NOTIFICATIONS.QUESTION_ID, questionUUIDs.first())
+                questionUUIDs.slice(1 until questionUUIDs.size)
+                    .fold(firstRecord) { step, questionUUID ->
+                        step.newRecord()
+                            .set(Tables.EMAIL_NOTIFICATIONS.NOTIFICATION_TYPE, notificationType.name)
+                            .set(Tables.EMAIL_NOTIFICATIONS.QUESTION_ID, questionUUID)
+                    }
+                    .onDuplicateKeyIgnore().execute()
+            }
+        }
+    }
+
+    override fun all(): List<EmailNotification> {
+        return ctx.select().from(Tables.EMAIL_NOTIFICATIONS).fetchInto(EmailNotification::class.java)
+    }
+}

--- a/persistence/src/main/kotlin/com/joe/quizzy/persistence/modules/QuizzyPersistenceModule.kt
+++ b/persistence/src/main/kotlin/com/joe/quizzy/persistence/modules/QuizzyPersistenceModule.kt
@@ -1,11 +1,13 @@
 package com.joe.quizzy.persistence.modules
 
+import com.joe.quizzy.persistence.api.EmailNotificationDAO
 import com.joe.quizzy.persistence.api.GradeDAO
 import com.joe.quizzy.persistence.api.InstanceDAO
 import com.joe.quizzy.persistence.api.QuestionDAO
 import com.joe.quizzy.persistence.api.ResponseDAO
 import com.joe.quizzy.persistence.api.SessionDAO
 import com.joe.quizzy.persistence.api.UserDAO
+import com.joe.quizzy.persistence.impl.EmailNotificationDAOJooq
 import com.joe.quizzy.persistence.impl.GradeDAOJooq
 import com.joe.quizzy.persistence.impl.InstanceDAOJooq
 import com.joe.quizzy.persistence.impl.QuestionDAOJooq
@@ -32,5 +34,6 @@ class QuizzyPersistenceModule : KotlinModule() {
         bind<UserDAO>().to<UserDAOJooq>()
         bind<GradeDAO>().to<GradeDAOJooq>()
         bind<InstanceDAO>().to<InstanceDAOJooq>()
+        bind<EmailNotificationDAO>().to<EmailNotificationDAOJooq>()
     }
 }

--- a/persistence/src/main/resources/db/migration/V20200903131919__email_notification_records.sql
+++ b/persistence/src/main/resources/db/migration/V20200903131919__email_notification_records.sql
@@ -1,0 +1,21 @@
+create table email_notifications(
+    id UUID NOT NULL DEFAULT uuid_generate_v4(),
+    notification_type varchar(100),
+    question_id UUID,
+
+    FOREIGN KEY (question_id) references questions (id),
+    UNIQUE (question_id, notification_type),
+    PRIMARY KEY (id)
+);
+
+insert into email_notifications (
+    notification_type, question_id
+) (select 'REMINDER', id
+    from questions where sent_reminder
+);
+
+insert into email_notifications (
+    notification_type, question_id
+) (select 'ANSWER', id
+    from questions where sent_answer
+);

--- a/persistence/src/test/kotlin/com/joe/quizzy/persistence/impl/EmailNotificationDAOTest.kt
+++ b/persistence/src/test/kotlin/com/joe/quizzy/persistence/impl/EmailNotificationDAOTest.kt
@@ -1,0 +1,122 @@
+package com.joe.quizzy.persistence.impl
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.each
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import com.joe.quizzy.api.models.EmailNotification
+import com.joe.quizzy.api.models.Instance
+import com.joe.quizzy.api.models.NotificationType
+import com.joe.quizzy.api.models.Question
+import com.joe.quizzy.api.models.User
+import com.joe.quizzy.persistence.api.EmailNotificationDAO
+import com.joe.quizzy.persistence.api.InstanceDAO
+import com.joe.quizzy.persistence.api.QuestionDAO
+import com.joe.quizzy.persistence.api.UserDAO
+import org.testng.annotations.BeforeClass
+import org.testng.annotations.Test
+import java.time.OffsetDateTime
+
+class EmailNotificationDAOTest : PostgresDAOTestBase() {
+
+    lateinit var userDao: UserDAO
+    lateinit var instanceDao: InstanceDAO
+    lateinit var questionDao: QuestionDAO
+    lateinit var dao: EmailNotificationDAO
+
+    @BeforeClass
+    override fun setUp() {
+        super.setUp()
+        questionDao = QuestionDAOJooq(ctx)
+        userDao = UserDAOJooq(ctx)
+        instanceDao = InstanceDAOJooq(ctx)
+        dao = EmailNotificationDAOJooq(ctx)
+    }
+
+    @Test
+    fun testMarkNotified() {
+        val instance = Instance(null, "emailNotificationDAOInstance", "ACTIVE")
+        val instanceId = instanceDao.save(instance).id!!
+        val user = User(null, instanceId, "abc", "abc@gmail.com", null, false, "UTC")
+        val userId = userDao.save(user).id!!
+        val questions = listOf(
+            Question(null, userId, "q1", "a1", "r1", OffsetDateTime.now(), OffsetDateTime.now()),
+            Question(null, userId, "q2", "a2", "r2", OffsetDateTime.now(), OffsetDateTime.now()),
+            Question(null, userId, "q3", "a3", "r3", OffsetDateTime.now(), OffsetDateTime.now()),
+        ).map {
+            questionDao.save(it)
+        }
+        dao.markNotified(NotificationType.REMINDER, listOf())
+        assertThat(dao.all()).isEmpty()
+
+        dao.markNotified(NotificationType.REMINDER, listOfNotNull(questions[0].id))
+        assertThat(dao.all()).hasSize(1)
+        assertThat(dao.all().first().questionId).isEqualTo(questions[0].id)
+        assertThat(dao.all().first().notificationType).isEqualTo(NotificationType.REMINDER)
+
+        dao.markNotified(NotificationType.ANSWER, listOfNotNull(questions[0].id))
+        assertThat(dao.all()).hasSize(2)
+        assertThat(dao.all().map { it.questionId }).each {
+            it.isEqualTo(questions[0].id)
+        }
+        assertThat(dao.all().map { it.notificationType }).contains(NotificationType.REMINDER)
+        assertThat(dao.all().map { it.notificationType }).contains(NotificationType.ANSWER)
+
+        dao.markNotified(NotificationType.REMINDER, listOfNotNull(questions[0].id))
+        dao.markNotified(NotificationType.ANSWER, listOfNotNull(questions[0].id))
+        assertThat(dao.all()).hasSize(2)
+        assertThat(dao.all().map { it.questionId }).each {
+            it.isEqualTo(questions[0].id)
+        }
+        assertThat(dao.all().map { it.notificationType }).contains(NotificationType.REMINDER)
+        assertThat(dao.all().map { it.notificationType }).contains(NotificationType.ANSWER)
+
+        dao.markNotified(NotificationType.REMINDER, questions.slice(0..1).mapNotNull { it.id })
+        assertThat(dao.all()).hasSize(3)
+        assertThat(dao.all().map { it.copy(id = null) }).all {
+            contains(
+                EmailNotification(
+                    null,
+                    NotificationType.ANSWER,
+                    questions[0].id!!
+                )
+            )
+            contains(
+                EmailNotification(
+                    null,
+                    NotificationType.REMINDER,
+                    questions[0].id!!
+                )
+            )
+            contains(
+                EmailNotification(
+                    null,
+                    NotificationType.REMINDER,
+                    questions[1].id!!
+                )
+            )
+        }
+
+        dao.markNotified(NotificationType.ANSWER, questions.slice(0..1).mapNotNull { it.id })
+        assertThat(dao.all()).hasSize(4)
+        assertThat(dao.all().map { it.copy(id = null) }).all {
+            for (question in questions.slice(0..1)) {
+                contains(EmailNotification(null, NotificationType.ANSWER, question.id!!))
+                contains(EmailNotification(null, NotificationType.REMINDER, question.id!!))
+            }
+        }
+
+        dao.markNotified(NotificationType.REMINDER, questions.mapNotNull { it.id })
+        dao.markNotified(NotificationType.ANSWER, questions.mapNotNull { it.id })
+        assertThat(dao.all()).hasSize(6)
+        assertThat(dao.all().map { it.copy(id = null) }).all {
+            for (question in questions) {
+                contains(EmailNotification(null, NotificationType.ANSWER, question.id!!))
+                contains(EmailNotification(null, NotificationType.REMINDER, question.id!!))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Separate out from the Question object so that recordkeeping and
Question edits don't interfere with each other, fixing a bug where
questions couldn't be added or edited.