### PR TITLE
Use new codecov uploader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,14 +82,23 @@ jobs:
       - run:
           name: Upload coverage report
           command: |
-            curl https://codecov.io/bash > ~/codecov
-            CODECOV_VERSION=$(grep 'VERSION=\".*\"' ~/codecov | cut -d '"' -f2)
-            curl "https://raw.githubusercontent.com/codecov/codecov-bash/${CODECOV_VERSION}/SHA512SUM" | grep codecov$ > ~/codecov.sha
-            cd ~ && shasum -a 512 -c ~/codecov.sha && cd ~/repo
+            echo $CODECOV_GPG_KEY | sed 's/\$/\n/g' | gpg --import
+            curl https://uploader.codecov.io/latest/linux/codecov > ~/codecov
+            curl https://uploader.codecov.io/latest/linux/codecov.SHA256SUM > ~/codecov.SHA256SUM
+            curl https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig > ~/codecov.SHA256SUM.sig
+            cd ~
+            gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
+            if [ $? -ne 0 ]; then
+             echo "bad signature on codecov SHA256SUM file"
+             exit 1
+            fi
+            shasum -a 256  -c codecov.SHA256SUM
             if [ $? -eq 0 ]; then
               chmod +x ~/codecov
+              cd ~/repo
               ~/codecov -t ${CODECOV_TOKEN}
             else
+              echo "bad checksum on codecov binary"
               exit 1
             fi
       # collect docs


### PR DESCRIPTION
The codecov bash uploader is deprecated, move over to the
new one, and verify its checksum and gpg signature before
executing it.