### PR TITLE
Use jooq's DDLDatabase to generate schema

### DIFF
--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -79,82 +79,37 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <!-- always clean the generated db during a build -->
-                    <execution>
-                        <id>autoclean-db</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                        <configuration>
-                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
-                            <filesets>
-                                <fileset>
-                                    <directory>${project.build.directory}</directory>
-                                    <includes>
-                                        <include>builddb</include>
-                                        <include>builddb.*</include>
-                                    </includes>
-                                </fileset>
-                            </filesets>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.flywaydb</groupId>
-                <artifactId>flyway-maven-plugin</artifactId>
-                <configuration>
-                    <url>jdbc:h2:${project.build.directory}/builddb;DATABASE_TO_UPPER=false</url>
-                    <locations>
-                        <location>filesystem:src/main/resources/db/migration</location>
-                    </locations>
-                    <sqlMigrationSuffixes>
-                        <sqlMigrationSuffix>.sql</sqlMigrationSuffix>
-                        <sqlMigrationSuffix>.h2sql</sqlMigrationSuffix>
-                    </sqlMigrationSuffixes>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.h2database</groupId>
-                        <artifactId>h2</artifactId>
-                        <version>${version.h2}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-            <plugin>
                 <groupId>org.jooq</groupId>
                 <artifactId>jooq-codegen-maven</artifactId>
                 <dependencies>
                     <dependency>
-                        <groupId>com.h2database</groupId>
-                        <artifactId>h2</artifactId>
-                        <version>${version.h2}</version>
+                        <groupId>org.jooq</groupId>
+                        <artifactId>jooq-meta-extensions</artifactId>
+                        <version>${version.jooq}</version>
                     </dependency>
                 </dependencies>
                 <configuration>
-                    <jdbc>
-                        <url>
-                            jdbc:h2:${project.build.directory}/builddb
-                        </url>
-                    </jdbc>
                     <generator>
                         <database>
-                            <name>org.jooq.meta.jdbc.JDBCDatabase</name>
+                            <name>org.jooq.meta.extensions.ddl.DDLDatabase</name>
                             <includes>.*</includes>
                             <inputSchema>PUBLIC</inputSchema>
-                            <forcedTypes>
-                                <forcedType>
-                                    <userType>java.time.YearMonth</userType>
-                                    <converter>com.trib3.db.converters.YearMonthConverter</converter>
-                                    <expression>MONTH</expression>
-                                    <types>DATE</types>
-
-                                </forcedType>
-                            </forcedTypes>
+                            <properties>
+                                <property>
+                                    <key>scripts</key>
+                                    <value>
+                                        src/main/resources/db/migration/*.sql
+                                    </value>
+                                </property>
+                                <property>
+                                    <key>sort</key>
+                                    <value>flyway</value>
+                                </property>
+                                <property>
+                                    <key>defaultNameCase</key>
+                                    <value>lower</value>
+                                </property>
+                            </properties>
                         </database>
                         <target>
                             <packageName>com.joe.quizzy.persistence.impl.jooq</packageName>

--- a/persistence/src/main/resources/db/migration/V20200324000000__extension_enable.h2sql
+++ b/persistence/src/main/resources/db/migration/V20200324000000__extension_enable.h2sql
@@ -1,5 +1,0 @@
-CREATE ALIAS uuid_generate_v4 AS $$
-UUID uuid_generate_v4() {
-    return null;
-}
-$$;

--- a/persistence/src/main/resources/db/migration/V20200324125333__initialmigration.sql
+++ b/persistence/src/main/resources/db/migration/V20200324125333__initialmigration.sql
@@ -1,5 +1,5 @@
 create table instances(
-    id UUID NOT NULL DEFAULT uuid_generate_v4(),
+    id UUID NOT NULL /* [jooq ignore start] */ DEFAULT uuid_generate_v4() /* [jooq ignore stop] */,
     name varchar(255),
     status text,
     UNIQUE (name),
@@ -7,7 +7,7 @@ create table instances(
 );
 
 create table users(
-    id UUID NOT NULL DEFAULT uuid_generate_v4(),
+    id UUID NOT NULL /* [jooq ignore start] */ DEFAULT uuid_generate_v4() /* [jooq ignore stop] */,
     instance_id UUID,
     name text,
     email varchar(255),
@@ -20,7 +20,7 @@ create table users(
 );
 
 create table questions(
-    id UUID NOT NULL DEFAULT uuid_generate_v4(),
+    id UUID NOT NULL /* [jooq ignore start] */ DEFAULT uuid_generate_v4() /* [jooq ignore stop] */,
     author_id UUID,
     body text,
     answer text,
@@ -32,7 +32,7 @@ create table questions(
 );
 
 create table responses(
-    id UUID NOT NULL DEFAULT uuid_generate_v4(),
+    id UUID NOT NULL /* [jooq ignore start] */ DEFAULT uuid_generate_v4() /* [jooq ignore stop] */,
     user_id UUID,
     question_id UUID,
     response text,
@@ -46,7 +46,7 @@ create table responses(
 );
 
 create table sessions(
-    id UUID NOT NULL DEFAULT uuid_generate_v4(),
+    id UUID NOT NULL /* [jooq ignore start] */ DEFAULT uuid_generate_v4() /* [jooq ignore stop] */,
     user_id UUID,
     created_at TIMESTAMP WITH TIME ZONE,
     last_used_at TIMESTAMP WITH TIME ZONE,

--- a/persistence/src/main/resources/db/migration/V20200428081848__add_grade_table.sql
+++ b/persistence/src/main/resources/db/migration/V20200428081848__add_grade_table.sql
@@ -1,5 +1,5 @@
 create table grades(
-    id UUID NOT NULL DEFAULT uuid_generate_v4(),
+    id UUID NOT NULL /* [jooq ignore start] */ DEFAULT uuid_generate_v4() /* [jooq ignore stop] */,
     response_id UUID,
     correct bool,
     bonus int,

--- a/persistence/src/main/resources/db/migration/V20200903131919__email_notification_records.sql
+++ b/persistence/src/main/resources/db/migration/V20200903131919__email_notification_records.sql
@@ -1,5 +1,5 @@
 create table email_notifications(
-    id UUID NOT NULL DEFAULT uuid_generate_v4(),
+    id UUID NOT NULL /* [jooq ignore start] */ DEFAULT uuid_generate_v4() /* [jooq ignore stop] */,
     notification_type varchar(100),
     question_id UUID,
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,11 +9,11 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>[1.27.1,1.28-SNAPSHOT)</version>
+        <version>[1.28.1,1.29-SNAPSHOT)</version>
     </parent>
 
     <properties>
-        <version.leakycauldron>[1.27.1,1.28-SNAPSHOT)</version.leakycauldron>
+        <version.leakycauldron>[1.28.1,1.29-SNAPSHOT)</version.leakycauldron>
 
         <version.argon>2.11</version.argon>
         <version.google-http-client>1.40.1</version.google-http-client>


### PR DESCRIPTION
Instead of manually running flyway against an h2 database,
use jooq's DDLDatabase to generate schema in a single step.
Update migration scripts to account for differences in jooq
vs/ postgres uuid generation functions, ignore the default
uuid clause during jooq generation.

Upgrade to leakycauldron 1.28.x.